### PR TITLE
Remove django.contrib.contenttypes from TENANT_APPS

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS.insert(0, 'django_tenants')
 INSTALLED_APPS.insert(1, 'tcms_tenants')
 
 TENANT_APPS = [
-    'django.contrib.contenttypes',
     'django.contrib.sites',
 
     'attachments',


### PR DESCRIPTION
otherwise causes missing permissions when creating TestCases on
tenants.