### PR TITLE
tests: Remove tcms.core.contrib.comments from TENANT_APPS

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -52,7 +52,6 @@ TENANT_APPS = [
     'simple_history',
 
     'tcms.bugs',
-    'tcms.core.contrib.comments.apps.AppConfig',
     'tcms.core.contrib.linkreference',
     'tcms.management',
     'tcms.testcases.apps.AppConfig',


### PR DESCRIPTION
after being removed from the main app here
https://github.com/kiwitcms/Kiwi/pull/1221