### PR TITLE
Always lower case schema_name

### DIFF
--- a/tcms_tenants/tests/test_views.py
+++ b/tcms_tenants/tests/test_views.py
@@ -89,6 +89,24 @@ class NewTenantViewTestCase(LoggedInTestCase):
         self.assertTrue(tenant.on_trial)
         self.assertIsNone(tenant.paid_until)
 
+    def test_create_tenant_always_uses_lowercase_schema_name(self):
+        expected_url = 'https://lowercase.%s' % settings.KIWI_TENANTS_DOMAIN
+        response = self.client.post(
+            reverse('tcms_tenants:create-tenant'),
+            {
+                'name': 'Low Case LLC.',
+                'schema_name': 'LowerCase',
+                # this is what the default form view sends
+                'on_trial': True,
+                'paid_until': '',
+            })
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response['Location'], expected_url)
+
+        self.assertTrue(
+            Tenant.objects.filter(schema_name='lowercase').exists())
+
     def test_create_tenant_with_name_schema_on_trial_payment_date(self):
         """
             Similar invocation will be used via inherited view in

--- a/tcms_tenants/utils.py
+++ b/tcms_tenants/utils.py
@@ -57,7 +57,7 @@ def tenant_url(request, schema_name):
 def create_tenant(form_data, request):
     owner = request.user
     name = form_data['name']
-    schema_name = form_data['schema_name']
+    schema_name = form_data['schema_name'].lower()
     on_trial = form_data['on_trial']
     paid_until = form_data['paid_until']
 
@@ -119,7 +119,7 @@ def create_oss_tenant(owner, name, schema_name, organization):
 
     data = {
         'name': name,
-        'schema_name': schema_name,
+        'schema_name': schema_name.lower(),
         'organization': organization,
         'on_trial': False,
         'paid_until': datetime.datetime(2999, 12, 31),


### PR DESCRIPTION
because Postgres and django_tenants allow upper case letters as
schema_name but that will not play well as a host name. Same
thing goes for `_` where it is allowed in DNS records and local
domain name but not as part of a hostname (e.g. FQDN). See
https://github.com/tomturner/django-tenants/issues/385

Ideally this will be resolved upstream!