### PR TITLE
Replace deprecated url() with re_path()

### DIFF
--- a/tcms_tenants/urls.py
+++ b/tcms_tenants/urls.py
@@ -1,13 +1,14 @@
-# Copyright (c) 2019 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2019-2020 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
 
-from django.conf.urls import url
+from django.urls import re_path
 from tcms_tenants import views
 
 app_name = 'tcms_tenants'
 
 urlpatterns = [
-    url(r'^create/$', views.NewTenantView.as_view(), name='create-tenant'),
-    url(r'^go/to/(?P<tenant>\w+)/(?P<path>.*)$', views.RedirectTo.as_view(), name='redirect-to'),
+    re_path(r'^create/$', views.NewTenantView.as_view(), name='create-tenant'),
+    re_path(r'^go/to/(?P<tenant>\w+)/(?P<path>.*)$',
+            views.RedirectTo.as_view(), name='redirect-to'),
 ]


### PR DESCRIPTION
to silence warnings with Django 3.1