### PR TITLE
Replace ModelChoiceField with UserField. Fixes #114

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,14 +65,18 @@ default tenant on which your application runs::
                               --name "Public tenant"
                               --paid_until 2050-12-31
                               --on_trial False
-                              --owner_id 1
+                              --owner_id 2
                               --organization "Testing department"
                               --domain-domain public.tenants.example.org
                               --domain-is_primary True
 
-**WARNING:** schema_name `public` is special, the rest is up to you.
-`owner_id` is usually the ID of the first superuser in the database which means
+**WARNING:** schema_name ``public`` is special, the rest is up to you.
+``owner_id`` is usually the ID of the first superuser in the database which means
 you must have executed ``createsuperuser`` first!
+
+**WARNING:** fresh installations of Kiwi TCMS v8.8 and later contain a special
+record with name ``AnonymousUser`` with ID == 1. Super-user will usually have an
+ID of 2 in this case! Pay attention to the ``owner_id`` value in the above command!
 
 You can use `create_tenant` afterwards to create other tenants for various teams
 or projects. Non-public tenants can also be created via the web interface as well.

--- a/tcms_tenants/admin.py
+++ b/tcms_tenants/admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2019-2020 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -7,9 +7,10 @@ from django import forms
 from django.urls import reverse
 from django.contrib import admin
 from django.forms.utils import ErrorList
-from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 from django.http import HttpResponseForbidden, HttpResponseRedirect
+
+from tcms.core.forms.fields import UserField
 
 from tcms_tenants.models import Tenant
 from tcms_tenants.utils import owns_tenant
@@ -65,8 +66,8 @@ class AuthorizedUsersChangeForm(forms.ModelForm):
     tenant = forms.models.ModelChoiceField(
         queryset=Tenant.objects.all(),
     )
-    user = forms.models.ModelChoiceField(
-        queryset=get_user_model().objects.all(),  # it is OK to be able to select between all users
+    user = UserField(  # pylint: disable=form-field-help-text-used
+        help_text=_('Existing username, email or user ID')
     )
 
     def __init__(self,  # pylint: disable=too-many-arguments

--- a/tcms_tenants/locale/en/LC_MESSAGES/django.po
+++ b/tcms_tenants/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-25 18:19+0000\n"
+"POT-Creation-Date: 2020-12-09 20:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: tcms_tenants/admin.py:39 tcms_tenants/middleware.py:32
+#: tcms_tenants/admin.py:41 tcms_tenants/middleware.py:32
 msgid "Unauthorized"
 msgstr ""
 
-#: tcms_tenants/admin.py:103
+#: tcms_tenants/admin.py:71
+msgid "Existing username, email or user ID"
+msgstr ""
+
+#: tcms_tenants/admin.py:105
 msgid "Username"
 msgstr ""
 
-#: tcms_tenants/admin.py:108
+#: tcms_tenants/admin.py:110
 msgid "Full name"
 msgstr ""
 

--- a/tcms_tenants/tests/test_admin.py
+++ b/tcms_tenants/tests/test_admin.py
@@ -121,23 +121,24 @@ class AuthorizedUsersAdminTestCase(LoggedInTestCase):
         response = self.client.post(
             reverse('admin:tcms_tenants_tenant_authorized_users_add'), {
                 # NOTE: No tenant field specified
-                'user': self.tester2.pk,
+                'user': self.tester2.username,
                 '_save': 'Save',
             })
 
         self.assertContains(response, "<ul class='errorlist'>", html=True)
         self.assertContains(response, "This field is required")
-        self.assertContains(response, "<option value=''>---------</option>", html=True)
+        self.assertContains(response, "<option value='' selected>---------</option>", html=True)
         self.assertContains(response,
                             "<option value='%d'>%s</option>" % (self.tenant.pk,
                                                                 self.tenant),
                             html=True)
         self.assertNotContains(response, self.tenant2)
 
-        self.assertContains(response,
-                            "<option value='%d' selected>%s</option>" % (self.tester2.pk,
-                                                                         self.tester2.username),
-                            html=True)
+        self.assertContains(
+            response,
+            '<input id="id_user" type="text" name="user" value="%s" required>' %
+            self.tester2.username,
+            html=True)
 
     def test_change_displays_only_current_tenant(self):
         self.assertGreater(utils.get_tenant_model().objects.filter(owner=self.tester).count(), 1)


### PR DESCRIPTION
this is a custom field which accepts username, email or ID and
is used in many places in Kiwi TCMS. Here it is used to avoid
presenting a huge list of existing accounts to the administrator
and making the selection a bit less clunky.

Still doesn't implement an auto-complete widget but that's
unrelated.