### PR TITLE
Don't add users to TenantGroup on `empty` tenant

### DIFF
--- a/tcms_tenants/tests/test_views.py
+++ b/tcms_tenants/tests/test_views.py
@@ -182,6 +182,11 @@ class NewTenantViewTestCase(TenantGroupsTestCase):
         tenant = create_oss_tenant(
             self.tester.username, 'osstenant', 'osstenant', 'Free Organization')
 
+        # assert tenant owner was added to default groups
+        with tenant_context(tenant):
+            self.assertTrue(tenant.owner.tenant_groups.filter(name="Administrator").exists())
+            self.assertTrue(tenant.owner.tenant_groups.filter(name="Tester").exists())
+
         # assert tenant was created
         self.assertFalse(tenant.publicly_readable)
         self.assertEqual(tenant.owner.pk, self.tester.pk)

--- a/tenant_groups/migrations/0001_initial.py
+++ b/tenant_groups/migrations/0001_initial.py
@@ -59,7 +59,7 @@ def forwards_add_default_groups_and_permissions(apps, schema_editor):
 
 def forwards_add_authorized_users_to_default_groups(apps, schema_editor):
     current_tenant = connections[get_tenant_database_alias()].tenant
-    if current_tenant.schema_name == get_public_schema_name():
+    if current_tenant.schema_name in [get_public_schema_name(), "empty"]:
         return
 
     group_model = apps.get_model("tenant_groups", "Group")


### PR DESCRIPTION
"empty" is a special tenant used as a template and we don't want to add any data here that may be copied to other tenants which would be created via cloning.