### PR TITLE
Update dependencies to Django>=6.0 and kiwitcms-django-tenants 3.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kiwitcms-django-tenants==3.8.1
+kiwitcms-django-tenants==3.8.2
 sqlparse>=0.5.4 # not directly required, pinned by Snyk to avoid a vulnerability
-django>=4.2.27 # not directly required, pinned by Snyk to avoid a vulnerability
+django>=6.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/tenant_groups/tests/test_admin.py
+++ b/tenant_groups/tests/test_admin.py
@@ -90,7 +90,7 @@ class TestGroupAdmin(TenantGroupsTestCase):
             'class="selectfilter" data-field-name="users" data-is-stacked="0">',
         )
         _capfirst = capfirst(_("users"))
-        self.assertContains(response, f'<label for="id_users">{_capfirst}')
+        self.assertContains(response, f'<legend for="id_users">{_capfirst}')
 
     @override_settings(LANGUAGE_CODE="en")
     def test_user_with_perms_should_be_able_to_delete_a_non_default_group(self):


### PR DESCRIPTION
Test & run multi-tenant support with Django >= 6.0 and kiwitcms-django-tenants 3.8.2. Upgrades version to 4.4.5.