### PR TITLE
Add location_for_schema property to TenantFileSystemStorage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,12 @@ to configure DNS resolution during development::
 Changelog
 ---------
 
+v4.6.0 (01 Jul 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Remove tenant's media directory when tenant is deleted
+
+
 v4.5.0 (17 Jun 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-tenants",
-    version="4.5.0",
+    version="4.6.0",
     description="Multi-tenant support for Kiwi TCMS",
     long_description=get_long_description(),
     author="Kiwi TCMS",

--- a/tcms_tenants/models.py
+++ b/tcms_tenants/models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2019-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
@@ -7,8 +7,10 @@ import os
 
 from django.db import models
 from django.conf import settings
+from django.core.files.storage import default_storage
 
 from django_tenants.models import TenantMixin, DomainMixin
+from django_tenants.utils import schema_context
 
 
 class Tenant(TenantMixin):
@@ -30,6 +32,13 @@ class Tenant(TenantMixin):
 
     def __str__(self):
         return f"[{self.schema_name}] {self.name}"
+
+    def delete(self, *args, **kwargs):
+        with schema_context(self.schema_name):
+            # NOTE: .location is tenant/schema aware
+            default_storage.delete_recursively(default_storage.location)
+
+        super().delete(*args, **kwargs)
 
 
 def _authorized_user_str(self):

--- a/tcms_tenants/storage.py
+++ b/tcms_tenants/storage.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2019-2020 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2019-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
 
 import os
+import shutil
 
 from django.conf import settings
 from django.utils.functional import cached_property
@@ -39,3 +40,6 @@ class TenantFileSystemStorage(FileSystemStorage):
             super().location, utils.parse_tenant_config_path(self.relative_media_root)
         )
         return os.path.abspath(_location)
+
+    def delete_recursively(self, path):  # pylint: disable=no-self-use
+        shutil.rmtree(path)

--- a/tcms_tenants/tests/test_storage.py
+++ b/tcms_tenants/tests/test_storage.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2019-2025 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2019-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
 
 # pylint: disable=too-many-ancestors
+import os
+
 from django.db import connection
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -84,3 +86,36 @@ class DefaultStorageTestCase(TenantFileSystemStorageTestCase):
     """
 
     storage = default_storage
+
+
+class TenantDeleteTestCase(LoggedInTestCase):
+    @override_settings(
+        MEDIA_ROOT="apps_dir/media",
+        MEDIA_URL="/media/",
+        MULTITENANT_RELATIVE_MEDIA_ROOT="%s",
+    )
+    def test_tenant_delete_removes_media_directory(self):
+        connection.set_schema_to_public()
+        tenant = utils.get_tenant_model()(
+            schema_name="tenant_to_delete", owner=UserFactory(), name="To Delete"
+        )
+        tenant.save()
+
+        # Save a file under this tenant schema's storage
+        with utils.tenant_context(tenant):
+            file_name = default_storage.save(
+                "hello_delete.txt", ContentFile("Hello Delete")
+            )
+            # convert to absolute path
+            file_name = default_storage.path(file_name)
+            self.assertTrue(default_storage.exists(file_name))
+
+            tenant_storage_dir = os.path.dirname(file_name)
+            self.assertTrue(default_storage.exists(tenant_storage_dir))
+
+        # Delete the tenant
+        tenant.delete()
+
+        # The tenant's storage directory (which includes the file) should be removed
+        self.assertFalse(os.path.exists(file_name))
+        self.assertFalse(os.path.exists(tenant_storage_dir))


### PR DESCRIPTION
New `location_for_schema` method on `TenantFileSystemStorage` that accepts a `schema_name` and returns the schema name injected into `relative_media_root`.

Uses the same `%s` / append logic as `parse_tenant_config_path` but operates on a caller-supplied schema name instead of `connection.schema_name`.

Also bumps copyright year to 2026 in both `storage.py` and `test_storage.py`.