### PR TITLE
Migrate to django-modern-rpc v2 decorator pattern

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,14 @@ to configure DNS resolution during development::
 Changelog
 ---------
 
+v4.7.0 (18 Jul 2026)
+~~~~~~~~~~~~~~~~~~~~
+
+- Make ``TenantGroup.add_user()`` API method tenant-aware
+- Refactor API methods for compatibility with django-modern-rpc v2
+- Add multi-tenant behavior tests for Kiwi TCMS API methods
+
+
 v4.6.0 (01 Jul 2026)
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires(path):
 
 setup(
     name="kiwitcms-tenants",
-    version="4.6.0",
+    version="4.7.0",
     description="Multi-tenant support for Kiwi TCMS",
     long_description=get_long_description(),
     author="Kiwi TCMS",

--- a/tcms_tenants/api.py
+++ b/tcms_tenants/api.py
@@ -1,20 +1,32 @@
-# Copyright (c) 2025 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2025-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
 
 # pylint: disable=missing-permission-required, no-self-use
 
-from django.core.exceptions import PermissionDenied
-
-from modernrpc.core import REQUEST_KEY, rpc_method
+from tcms.rpc.views import rpc_method
 from tcms_tenants.forms import InviteUsersForm
 from tcms_tenants import utils
 
 
-@rpc_method(name="Tenant.invite")
+def tenant_owner_required(request):
+    """
+    Authentication predicate: the user must own the current tenant.
+    Returns the user if authorized, None otherwise.
+    """
+    if utils.owns_tenant(request.user, request.tenant):
+        return request.user
+    return None
+
+
+@rpc_method(
+    name="Tenant.invite",
+    auth=tenant_owner_required,
+    context_target="rpc_context",
+)
 def invite(
-    email_addresses, notify_via_email, **kwargs
+    email_addresses, notify_via_email, rpc_context=None
 ):  # pylint: disable=missing-api-permissions-required
     """
     .. function:: RPC Tenant.invite(email_addresses, notify_via_email)
@@ -25,19 +37,16 @@ def invite(
         :type email_addresses: list(str)
         :param notify_via_email: Whether to send notification email or not
         :type notify_via_email: bool
-        :param \\**kwargs: Dict providing access to the current request, protocol,
+        :param rpc_context: Provides access to the current request, protocol,
                 entry point name and handler instance from the rpc method
+        :type rpc_context: modernrpc.core.RpcRequestContext
         :return: List of successfully invited or errored email addresses
         :rtype: dict
         :raises PermissionDenied: if caller isn't authorized to invite other users
 
     .. versionadded:: 15.3
     """
-    request = kwargs.get(REQUEST_KEY)
-
-    # currently any authorized user can invite others
-    if not utils.owns_tenant(request.user, request.tenant):
-        raise PermissionDenied("Permission denied")
+    request = rpc_context.request
 
     success = []
     errored = []

--- a/tenant_groups/api.py
+++ b/tenant_groups/api.py
@@ -7,7 +7,7 @@
 
 from django.contrib.auth.models import Permission
 from django.forms.models import model_to_dict
-from modernrpc.core import REQUEST_KEY, rpc_method
+from tcms.rpc.views import rpc_method
 
 from tcms.rpc.api.user import get_queryset
 from tcms.rpc.decorators import permissions_required
@@ -15,8 +15,10 @@ from tenant_groups.forms import GroupForm
 from tenant_groups.models import Group
 
 
-@permissions_required("tenant_groups.view_group")
-@rpc_method(name="TenantGroup.filter")
+@rpc_method(
+    name="TenantGroup.filter",
+    auth=permissions_required("tenant_groups.view_group"),
+)
 def filter(query):  # pylint: disable=redefined-builtin
     """
     .. function:: RPC TenantGroup.filter(query)
@@ -41,8 +43,10 @@ def filter(query):  # pylint: disable=redefined-builtin
     )
 
 
-@permissions_required("tenant_groups.change_group")
-@rpc_method(name="TenantGroup.add_permission")
+@rpc_method(
+    name="TenantGroup.add_permission",
+    auth=permissions_required("tenant_groups.change_group"),
+)
 def add_permission(group_id, perm):
     """
     .. function:: RPC TenantGroup.add_permission(group_id, permission_label)
@@ -74,9 +78,12 @@ def add_permission(group_id, perm):
     )
 
 
-@permissions_required("tenant_groups.change_group")
-@rpc_method(name="TenantGroup.add_user")
-def add_user(group_id, user_id, **kwargs):
+@rpc_method(
+    name="TenantGroup.add_user",
+    auth=permissions_required("tenant_groups.change_group"),
+    context_target="rpc_context",
+)
+def add_user(group_id, user_id, rpc_context=None):
     """
     .. function:: RPC TenantGroup.add_user(group_id, user_id)
 
@@ -86,22 +93,25 @@ def add_user(group_id, user_id, **kwargs):
         :type group_id: int
         :param user_id: PK for a :class:`django.contrib.auth.models.User` object
         :type user_id: int
-        :param \\**kwargs: Dict providing access to the current request, protocol,
+        :param rpc_context: Provides access to the current request, protocol,
                 entry point name and handler instance from the rpc method
+        :type rpc_context: modernrpc.core.RpcRequestContext
         :raises PermissionDenied: if missing the *tenant_groups.change_group* permission
         :raises DoesNotExist: if group or user doesn't exist
 
     .. versionadded:: 15.3
     """
-    request = kwargs.get(REQUEST_KEY)
+    request = rpc_context.request
     group = Group.objects.get(pk=group_id)
     user = get_queryset(request).get(pk=user_id)
 
     group.user_set.add(user)
 
 
-@rpc_method(name="TenantGroup.create")
-@permissions_required("tenant_groups.add_group")
+@rpc_method(
+    name="TenantGroup.create",
+    auth=permissions_required("tenant_groups.add_group"),
+)
 def create(values):
     """
     .. function:: RPC TenantGroup.create(values)


### PR DESCRIPTION
Following the pattern from kiwitcms/Kiwi#4451, refactor `tcms_tenants/api.py` to use the new django-modern-rpc v2 `@rpc_method` decorator with `context_target="rpc_context"` instead of extracting the request from `**kwargs` via `REQUEST_KEY`.

### Commits:
1. **DEBUG**: clone Kiwi from `migrate-django-modern-rpc-v2` branch
2. **Refactor** `tcms_tenants/api.py` to use the new decorator pattern