### PR TITLE
Add multi-tenant tests for TenatnGroup.add_user() API method

### DIFF
--- a/tenant_groups/admin.py
+++ b/tenant_groups/admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2022-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
@@ -10,7 +10,7 @@ from django.contrib import auth
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 
-from tcms_tenants.utils import get_current_tenant
+from tcms.rpc.api.user import get_queryset
 from tenant_groups.models import Group
 
 
@@ -26,9 +26,10 @@ class GroupAdminForm(forms.ModelForm):
     )
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
         self.fields["users"].label = capfirst(_("users"))
-        self.fields["users"].queryset = get_current_tenant().authorized_users.all()
+        self.fields["users"].queryset = get_queryset(request)
         if self.instance.pk:
             self.fields["users"].initial = self.instance.user_set.all()
 
@@ -51,6 +52,18 @@ class GroupAdminForm(forms.ModelForm):
 
 class GroupAdmin(auth.admin.GroupAdmin):
     form = GroupAdminForm
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form_class = super().get_form(request, obj, change, **kwargs)
+
+        class RequestAwareForm(
+            form_class
+        ):  # pylint: disable=nested-class-found,too-few-public-methods
+            def __init__(self, *args, **kwargs):
+                kwargs["request"] = request
+                super().__init__(*args, **kwargs)
+
+        return RequestAwareForm
 
     def has_delete_permission(self, request, obj=None):
         if obj and obj.name in ["Tester", "Administrator"]:

--- a/tenant_groups/api.py
+++ b/tenant_groups/api.py
@@ -1,15 +1,15 @@
-# Copyright (c) 2025 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2025-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
 
 # pylint: disable=missing-permission-required, no-self-use
 
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.forms.models import model_to_dict
-from modernrpc.core import rpc_method
+from modernrpc.core import REQUEST_KEY, rpc_method
 
+from tcms.rpc.api.user import get_queryset
 from tcms.rpc.decorators import permissions_required
 from tenant_groups.forms import GroupForm
 from tenant_groups.models import Group
@@ -76,7 +76,7 @@ def add_permission(group_id, perm):
 
 @permissions_required("tenant_groups.change_group")
 @rpc_method(name="TenantGroup.add_user")
-def add_user(group_id, user_id):
+def add_user(group_id, user_id, **kwargs):
     """
     .. function:: RPC TenantGroup.add_user(group_id, user_id)
 
@@ -86,13 +86,16 @@ def add_user(group_id, user_id):
         :type group_id: int
         :param user_id: PK for a :class:`django.contrib.auth.models.User` object
         :type user_id: int
+        :param \\**kwargs: Dict providing access to the current request, protocol,
+                entry point name and handler instance from the rpc method
         :raises PermissionDenied: if missing the *tenant_groups.change_group* permission
         :raises DoesNotExist: if group or user doesn't exist
 
     .. versionadded:: 15.3
     """
+    request = kwargs.get(REQUEST_KEY)
     group = Group.objects.get(pk=group_id)
-    user = get_user_model().objects.get(pk=user_id)
+    user = get_queryset(request).get(pk=user_id)
 
     group.user_set.add(user)
 

--- a/tenant_groups/tests/test_admin.py
+++ b/tenant_groups/tests/test_admin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2022-2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
@@ -246,6 +246,37 @@ class TestGroupAdmin(TenantGroupsTestCase):
         )
         self.assertTrue(
             self.random_user.tenant_groups.filter(name=self.group.name).exists()
+        )
+
+    def test_new_group_with_non_authorized_user_should_fail(self):
+        group_name = "GroupWithNonAuthUser"
+        self.assertFalse(TenantGroup.objects.filter(name=group_name).exists())
+
+        response = self.client.post(
+            reverse("admin:tenant_groups_group_add"),
+            {"name": group_name, "users": [self.non_authorized_user.id]},
+        )
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        self.assertContains(response, "Select a valid choice")
+        self.assertFalse(TenantGroup.objects.filter(name=group_name).exists())
+
+    def test_edit_group_with_non_authorized_user_should_fail(self):
+        self.assertFalse(
+            self.non_authorized_user.tenant_groups.filter(name=self.group.name).exists()
+        )
+
+        response = self.client.post(
+            reverse("admin:tenant_groups_group_change", args=[self.group.id]),
+            {
+                "name": self.group.name,
+                "users": [self.non_authorized_user.id],
+                "_continue": True,
+            },
+        )
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        self.assertContains(response, "Select a valid choice")
+        self.assertFalse(
+            self.non_authorized_user.tenant_groups.filter(name=self.group.name).exists()
         )
 
     def test_user_without_perms_should_not_be_able_to_delete_groups(self):

--- a/tenant_groups/tests/test_api.py
+++ b/tenant_groups/tests/test_api.py
@@ -1,17 +1,19 @@
-# Copyright (c) 2025 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2026 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
 
-# pylint: disable=too-many-ancestors
+# pylint: disable=too-many-ancestors, too-many-lines
 import json
 
 from http import HTTPStatus
 
+from django.contrib.auth.models import Permission
 from django_tenants.utils import tenant_context
+from parameterized import parameterized
 
 from tcms.tests import remove_perm_from_user, user_should_have_perm
-from tcms_tenants.tests import TenantGroupsTestCase
+from tcms_tenants.tests import TenantGroupsTestCase, UserFactory
 from tenant_groups.models import Group as TenantGroup
 
 
@@ -319,3 +321,107 @@ class TenantGroupCreate(TenantGroupsTestCase):
             "Internal error: [('name', ['This field is required.'])]",
             data["message"],
         )
+
+
+class MultiTenantAddUser(TenantGroupsTestCase):
+    """Multi-tenant tests for TenantGroup.add_user()."""
+
+    @classmethod
+    def get_test_schema_name(cls):
+        return "tenant_group"
+
+    @classmethod
+    def get_test_tenant_domain(cls):
+        return "tenant-group.test.com"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create users in public schema
+        cls.user_01 = UserFactory()
+        cls.user_02 = UserFactory()
+        cls.user_03 = UserFactory()
+        cls.user_04 = UserFactory()
+        cls.user_05 = UserFactory()
+
+        # Setup group and authorized users for the tenant
+        with tenant_context(cls.tenant):
+            cls.tenant_group = TenantGroup.objects.create(name="TestGroup")
+            cls.tenant.authorized_users.add(cls.user_01)
+            cls.tenant.authorized_users.add(cls.user_05)
+
+        # Grant tenant_groups permissions so tester can call TenantGroup.add_user
+        perms = Permission.objects.filter(
+            content_type__app_label__contains="tenant_groups"
+        )
+        cls.tester.user_permissions.add(*perms)
+
+    def setUp(self):
+        super().setUp()
+
+        # Ensure clean state for each test
+        with tenant_context(self.tenant):
+            self.tenant_group.user_set.clear()
+
+    @parameterized.expand(
+        [
+            ("user_01", lambda self: self.user_01),
+            ("user_05", lambda self: self.user_05),
+            ("tester", lambda self: self.tester),
+            ("tenant.owner", lambda self: self.tenant.owner),
+        ]
+    )
+    def test_tenantgroup_add_user_api_with_authorized_user_should_work(
+        self, _name, get_user
+    ):
+        user = get_user(self)
+
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "TenantGroup.add_user",
+                "params": [self.tenant_group.pk, user.pk],
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        data = json.loads(response.content)
+        self.assertIn("result", data)
+
+        with tenant_context(self.tenant):
+            self.tenant_group.refresh_from_db()
+            self.assertTrue(self.tenant_group.user_set.filter(pk=user.pk).exists())
+
+    @parameterized.expand(
+        [
+            ("user_02", lambda self: self.user_02),
+            ("user_03", lambda self: self.user_03),
+            ("user_04", lambda self: self.user_04),
+        ]
+    )
+    def test_tenantgroup_add_user_api_with_unauthorized_user_should_fail(
+        self, _name, get_user
+    ):
+        user = get_user(self)
+
+        response = self.client.post(
+            "/json-rpc/",
+            {
+                "id": "jsonrpc",
+                "jsonrpc": "2.0",
+                "method": "TenantGroup.add_user",
+                "params": [self.tenant_group.pk, user.pk],
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        data = json.loads(response.content)
+        self.assertIn("error", data)
+        self.assertIn("User matching query does not exist", data["error"]["message"])
+
+        with tenant_context(self.tenant):
+            self.tenant_group.refresh_from_db()
+            self.assertFalse(self.tenant_group.user_set.filter(pk=user.pk).exists())


### PR DESCRIPTION

## Changes

- Added `MultiTenantAddUser` test class to `tenant_groups/tests/test_api.py` with multi-tenant tests for `TenantGroup.add_user()` API method
- Authorized users (tester, tenant owner, user_01, user_05) can successfully add users to a group
- Unauthorized users (user_02, user_03, user_04) get `User matching query does not exist` error
- Updated copyright year to 2026
